### PR TITLE
Use fat arrows to fix context object in JS output

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -30,14 +30,14 @@ export default class WaterRower {
         });
 
         // when the port opens, initialize it
-        this.port.on('open', function () {
+        this.port.on('open', () => {
             console.log(`A connection to the WaterRower has been established on ${portName}`);
 
             this.initialize(); //start things off
             this.setDisplayUnits(); //change the display to meters
             this.reset(); //reset the waterrower 
 
-            setInterval(function () {
+            setInterval(() => {
                 this.requestDistance();
                 this.requestSpeed();
                 this.requestClock();


### PR DESCRIPTION
The TypeScript compiler was interpreting these two callbacks as full JS function expressions (`function () { … }`), which meant their context objects (`this`) no longer referred to the current WaterRower instance at execution.

Replacing the function expressions with fat arrows (`() => {`) means they get lexical `this`, fixing the `tsc -w` output.
