### PR TITLE
Add .npmignore to keep compiled JS in the published NPM package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,6 @@
+*.ts
+
+/.vscode
+/tsconfig.json
+/typings
+/typings.json


### PR DESCRIPTION
The current (0.1.0) NPM package is missing `config.js`. This is because `.gitignore` [excludes all JS files](https://github.com/codefoster/waterrower/blob/0156f2083ee7954eb645e8235f342920a657eb55/.gitignore#L37) and if no `.npmignore` file is present then `npm publish` uses `.gitignore` when deciding what to include in the published package. (`index.js` was still included because [it's listed as the main entry point in `package.json`](https://github.com/codefoster/waterrower/blob/0156f2083ee7954eb645e8235f342920a657eb55/package.json#L5), which takes precedence over `.gitignore` in the publish step.)

To make sure compiled JS gets included in the published NPM package from now on I've created an `.npmignore`, which excludes the TypeScript sources and configurations but allows the compiled JS to be included.

You can preview the effect of this change with [irish-pub](https://www.npmjs.com/package/irish-pub), which is something like a dry run of `npm publish`:

```
$ irish-pub
npm will publish waterrower@0.1.0 as redopop, including the following files:

package.json
.npmignore
config.js
index.js
index.js.map
config.js.map
LICENSE.md
readme.md
```
