### PR TITLE
Force WaterRower instance as action context object

### DIFF
--- a/actions.ts
+++ b/actions.ts
@@ -7,7 +7,7 @@ export default [
     {
         name: 'distance (low byte)',
         pattern: /IDS055([\dA-F]+)/,
-        action: m => {
+        action: function (m) {
             if (this.distance_l != m[1]) {
                 this.distance_l = m[1];
                 this.data$.next(null);
@@ -17,12 +17,14 @@ export default [
     {
         name: 'distance (high byte)',
         pattern: /IDS056([\dA-F]+)/,
-        action: m => this.distance_h = m[1]
+        action: function(m) {
+            this.distance_h = m[1]
+        }
     },
     {
         name: 'speed (low byte)',
         pattern: /IDS14A([\dA-F]+)/,
-        action: m => {
+        action: function (m) {
             if (this.speed_l != m[1])
                 this.speed_l = m[1];
         }
@@ -30,7 +32,7 @@ export default [
     {
         name: 'speed (high byte)',
         pattern: /IDS14B([\dA-F]+)/,
-        action: m => {
+        action: function (m) {
             if (this.speed_h != m[1]) {
                 this.speed_h = m[1];
                 this.data$.next(null);
@@ -40,7 +42,7 @@ export default [
     {
         name: 'stroke rate',
         pattern: /IDS142([\dA-F]+)/,
-        action: m => {
+        action: function (m) {
             if (this.strokeRate != m[1]) {
                 this.strokeRate = m[1];
                 this.data$.next(null);
@@ -50,7 +52,7 @@ export default [
     {
         name: 'clock (seconds)',
         pattern: /IDS1E1([\dA-F]+)/,
-        action: m => {
+        action: function (m) {
             if (this.clock != m[1]) {
                 this.clock = m[1];
                 this.data$.next(null);

--- a/index.ts
+++ b/index.ts
@@ -56,9 +56,9 @@ export default class WaterRower {
 
         //when a message is received, apply the appropriate action
         this.data$.subscribe(d => {
-            actions.forEach(function (a) {
+            actions.forEach(a => {
                 var matches = a.pattern.exec(d);
-                if (matches && a.action) a.action(matches);
+                if (matches && a.action) a.action.call(this, matches);
             });
         })
     }


### PR DESCRIPTION
In d98c1a0b58f24b1a81a5a4bcf04664ea5314a102, actions were moved into a separate file. Because their callbacks are fat arrow (`=>`) functions, the TypeScript JS compiler associates them with the global context object when generating `actions.js`, which is not the intended behavior.

To fix, I've changed actions to long-form functions, giving them their own context object that can be overridden at call time.
