### PR TITLE
Fix and complete the clock data

### DIFF
--- a/actions.ts
+++ b/actions.ts
@@ -50,11 +50,16 @@ export default [
         }
     },
     {
-        name: 'clock (seconds)',
-        pattern: /IDS1E1([\dA-F]+)/,
+        name: 'clock',
+        pattern: /IDT1E1(\d{02})(\d{02})(\d{02})/,
         action: function (m) {
-            if (this.clock != m[1]) {
-                this.clock = m[1];
+            const clock = (
+                parseInt(m[1], 10) * 3600 +  // hours
+                parseInt(m[2], 10) * 60 +    // minutes
+                parseInt(m[3], 10)           // seconds
+            );
+            if (this.clock != clock) {
+                this.clock = clock;
                 this.data$.next(null);
             }
         }

--- a/index.ts
+++ b/index.ts
@@ -79,7 +79,7 @@ export default class WaterRower {
             distance: ayb.hexToDec(this.distance_h + '' + this.distance_l),
             strokeRate: ayb.hexToDec(this.strokeRate.toString()),
             speed: ayb.hexToDec(this.speed_h + '' + this.speed_l),
-            clock: ayb.hexToDec(this.clock.toString()),
+            clock: this.clock,
         }
     }
 
@@ -107,7 +107,7 @@ export default class WaterRower {
 
     /// request clock data
     requestClock() {
-        this.send('IRS1E1'); //clock seconds
+        this.send('IRT1E1'); // clock seconds, minutes, hours
     }
 
     /// change the display to meters


### PR DESCRIPTION
A few things are going on in this commit:
- The clock is split across three memory locations: `1E1` (seconds 0-59), `1E2` (minutes 0-59), and `1E3` (hours 0-9). They're treated like a stopwatch, with the larger units incrementing whenever the smaller units complete a cycle. I've completed the clock data by collecting the values from all three locations.
- The protocol provides a method of collecting values from three locations at once, and I've chosen to use that here because otherwise there are synchronization issues (e.g. where the "seconds" counter resets before the "minutes" counter has incremented.)
- Oddly, the clock values aren't hexadecimal: they're decimal! I'm using `parseInt(, 10)` to make sure it's amply clear that we really do intend to parse them as such.

BTW, from the readme it sounds like there may be plans to make the clock a formatted value. FWIW I prefer it as an integer; as long as the units are clear in the docs I find an integer more useful and versatile than a human readable `HH:MM:SS` string.
